### PR TITLE
Cast tor_instances to Int when sleeping after tests

### DIFF
--- a/start.rb
+++ b/start.rb
@@ -210,7 +210,7 @@ loop do
     $logger.info "testing proxy #{proxy.id} (port #{proxy.port})"
     proxy.restart unless proxy.working?
     $logger.info "sleeping for #{tor_instances} seconds"
-    sleep tor_instances
+    sleep Integer(tor_instances)
   end
 
   $logger.info "sleeping for 60 seconds"


### PR DESCRIPTION
Ran into an error when running this where it crashed after running the first round of tests.  Casting the value to integer resolved the problem.